### PR TITLE
Correct config parsing warning

### DIFF
--- a/src/cli/run.rs
+++ b/src/cli/run.rs
@@ -45,7 +45,7 @@ async fn do_reload(
     let new_config = tokio_executor::blocking::run(move || {
         let mut file: &std::fs::File = &file;
         file.seek(SeekFrom::Start(0))?;
-        super::load_config_from_file(file)
+        super::load_config_from_file(file, false)
     })
     .await?;
     crate::cli::reload(wg, new_config).await

--- a/src/main.rs
+++ b/src/main.rs
@@ -97,7 +97,7 @@ impl Options {
         let options = self;
 
         let mut config = if let Some(ref p) = options.config_file {
-            cli::load_config_from_path(&p)?
+            cli::load_config_from_path(&p, true)?
         } else {
             cli::Config {
                 #[cfg(windows)]
@@ -228,7 +228,7 @@ impl Cmd {
                 }
             }
             Cmd::Check { config_file: p } => {
-                cli::load_config_from_path(&p)?;
+                cli::load_config_from_path(&p, true)?;
             }
             Cmd::Genpsk => {
                 let mut k = [0u8; 32];


### PR DESCRIPTION
Print to stderr when the logger has not been initialized, use the logger
otherwise.

Close #8.