### PR TITLE
Revert to reload configuration file by path

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,9 @@ accepted.
 # Set logging. Override by the `--log` option or the `RUST_LOG` environment variable.
 Log = "info"
 # Switch to user after initialization to drop privilege. Override by `--user`.
+#
+# If you use this option, and want to reload configuration, the configuration file
+# must be readable by this user.
 User = "nobody"
 # Switch to group.
 Group = "nogroup"


### PR DESCRIPTION
And document the restriction when using privilege dropping.

Because keeping an fd open is too confusing when using `mv`.