### PR TITLE
Run interoperability test in CI

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -48,8 +48,8 @@ jobs:
         set -ex
         sudo apt-add-repository -y ppa:wireguard/wireguard
         sudo apt-get update
-        sudo apt-get install -yqq wireguard-tools
-      displayName: Install WireGuard Tools
+        sudo apt-get install -yqq wireguard-dkms wireguard-tools
+      displayName: Install WireGuard DKMS and Tools
     - script: |
         set -ex
         sudo apt-get install -yqq libcurl4-openssl-dev libelf-dev libdw-dev cmake gcc binutils-dev libiberty-dev
@@ -73,6 +73,7 @@ jobs:
         cargo build
         cd ns-test
         sudo ./integration-test.sh
+        sudo ./interop-test.sh
       displayName: Run Integration Test
     - script: bash <(curl -s https://codecov.io/bash)
       displayName: Upload code coverage info to codecov.io

--- a/ns-test/interop-test.sh
+++ b/ns-test/interop-test.sh
@@ -1,5 +1,15 @@
 #!/bin/bash
 
+set -ex
+
+clean_up() {
+    set +e
+    r=$?
+    ./clean-up.sh
+    exit $r
+}
+trap clean_up EXIT
+
 ip netns add titun-test-1
 ip netns add titun-test-2
 ip -n titun-test-1 link add eth1 type veth peer name eth2 netns titun-test-2
@@ -12,12 +22,12 @@ ip -n titun-test-1 addr add 192.168.3.1/24 dev eth1
 ip -n titun-test-2 link set eth2 up mtu 9000
 ip -n titun-test-2 addr add 192.168.3.2/24 dev eth2
 
-TITUN_INTEROPE_TEST=1 RUST_LOG=debug ip netns exec titun-test-1 titun -f tun1 &
+TITUN_INTEROPE_TEST=1 ip netns exec titun-test-1 ../target/debug/titun -f tun1 &
 ip netns exec titun-test-2 ip link add tun2 type wireguard
 
-sleep 1
+while [ ! -e /var/run/wireguard/tun1.sock ]; do sleep 1; done
 
-ip netns exec titun-test-1 wg setconf tun1 tun1.conf
+wg setconf tun1 tun1.conf
 ip netns exec titun-test-2 wg setconf tun2 tun2.conf
 
 ip -n titun-test-1 link set tun1 up mtu 59000
@@ -25,6 +35,4 @@ ip -n titun-test-1 addr add 192.168.77.1/24 dev tun1
 ip -n titun-test-2 link set tun2 up mtu 1420
 ip -n titun-test-2 addr add 192.168.77.2/24 dev tun2
 
-ip netns exec titun-test-1 iperf3 -s 2>&1 > /dev/null &
-sleep 1
-ip netns exec titun-test-2 iperf3 -c 192.168.77.1
+ip netns exec titun-test-2 ping -W 10 -c 1 192.168.77.1


### PR DESCRIPTION
It seems that we can actually install kernel modules in azure-pipelines.

So why not run the interoperability test as well?