### PR TITLE
Infer interface name from config file name stem

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ to build a `titun` executable in `target/release`.
 Use
 
 ```sh
-$ sudo titun -c tun0.toml -f tun0
+$ sudo titun -fc tun0.toml
 ```
 
 to run TiTun and open the tun interface `tun0`. Here `-f` tells the program to
@@ -59,8 +59,6 @@ Foreground = true
 Threads = 2
 
 [Interface]
-# Optional. Override by command line argument. NOT applied when reloading.
-Name = "tun7"
 # Optiona. Alias: Port.
 ListenPort = 7777
 # Alias: Key.
@@ -97,7 +95,7 @@ Description=TiTun instance %I
 Type=notify
 Environment=RUST_BACKTRACE=1
 
-ExecStart=/usr/local/bin/titun -f -c /etc/titun/%I.conf %I
+ExecStart=/usr/local/bin/titun -fc /etc/titun/%I.conf
 ExecStartPost=/bin/sh -c "if [ -x /etc/titun/%I.up.sh ]; then /etc/titun/%I.up.sh; fi"
 ExecStopPost=/bin/sh -c "if [ -x /etc/titun/%I.down.sh ]; then /etc/titun/%I.down.sh; fi"
 

--- a/debian/package/lib/systemd/system/titun@.service
+++ b/debian/package/lib/systemd/system/titun@.service
@@ -5,7 +5,7 @@ Description=TiTun instance %I
 Type=notify
 Environment=RUST_BACKTRACE=1
 
-ExecStart=/usr/bin/titun -c /etc/titun/%I.conf -f %I
+ExecStart=/usr/bin/titun -fc /etc/titun/%I.conf
 ExecStartPost=/bin/sh -c "if [ -x /etc/titun/%I.up.sh ]; then /etc/titun/%I.up.sh; fi"
 ExecStopPost=/bin/sh -c "if [ -x /etc/titun/%I.down.sh ]; then /etc/titun/%I.down.sh; fi"
 

--- a/titun-windows-gui/titun-windows-gui/Config.cs
+++ b/titun-windows-gui/titun-windows-gui/Config.cs
@@ -25,8 +25,6 @@ namespace titun_windows_gui
 
     public class InterfaceConfig
     {
-        [Required]
-        public string Name { get; set; }
         [Ipv4Addr(ErrorMessage = "Address must be an IPv4 address")]
         public string Address { get; set; }
         [Range(0, 65536)]

--- a/titun-windows-gui/titun-windows-gui/MainWindow.xaml
+++ b/titun-windows-gui/titun-windows-gui/MainWindow.xaml
@@ -80,23 +80,6 @@
                                         </DataTemplate>
                                     </ItemsControl.ItemTemplate>
                                 </ItemsControl>
-                                <!--<DataGrid ItemsSource="{Binding Status.peers}" IsReadOnly="True" AutoGenerateColumns="False">
-                                    <DataGrid.CellStyle>
-                                        <Style TargetType="DataGridCell">
-                                            <Setter Property="Padding" Value="3"/>
-                                        </Style>
-                                    </DataGrid.CellStyle>
-                                    <DataGrid.Columns>
-                                        <DataGridTextColumn Header="Public Key" Binding="{Binding public_key_shown}"></DataGridTextColumn>
-                                        <DataGridTextColumn Header="PSK" Binding="{Binding has_psk}"></DataGridTextColumn>
-                                        <DataGridTextColumn Header="Endpoint" Binding="{Binding endpoint}"></DataGridTextColumn>
-                                        <DataGridTextColumn Header="Keepalive" Binding="{Binding persistent_keepalive_interval_shown}"></DataGridTextColumn>
-                                        <DataGridTextColumn Header="Last Handshake" Binding="{Binding last_handshake_shown}"></DataGridTextColumn>
-                                        <DataGridTextColumn Header="Received" Binding="{Binding rx_bytes_shown}"></DataGridTextColumn>
-                                        <DataGridTextColumn Header="Sent" Binding="{Binding tx_bytes_shown}"></DataGridTextColumn>
-                                        <DataGridTextColumn Header="Allowed IPs" Binding="{Binding allowed_ips_shown}"></DataGridTextColumn>
-                                    </DataGrid.Columns>
-                                </DataGrid>-->
                             </StackPanel>
                         </Border>
                     </TabItem>

--- a/titun-windows-gui/titun-windows-gui/MainWindow.xaml.cs
+++ b/titun-windows-gui/titun-windows-gui/MainWindow.xaml.cs
@@ -367,7 +367,8 @@ namespace titun_windows_gui
             task = ReadStream(titunProcess.StandardOutput.BaseStream);
 
             var getStatusCancellationTokenSource = new CancellationTokenSource();
-            task = GetStatus(getStatusCancellationTokenSource.Token, configObj.Interface.Name);
+            var interfaceName = Path.GetFileNameWithoutExtension(configFilePath);
+            task = GetStatus(getStatusCancellationTokenSource.Token, interfaceName);
 
             var haveRunAutoConfigure = false;
             IEnumerable<string> routes = null;
@@ -381,7 +382,7 @@ namespace titun_windows_gui
                     outputBuffer.Post("Auto config network.");
                     await Task.Run(delegate
                     {
-                        networkConfigManager.AutomaticConfig(configObj, outputBuffer, out routes);
+                        networkConfigManager.AutomaticConfig(interfaceName, configObj, outputBuffer, out routes);
                     });
                 }
             }

--- a/titun-windows-gui/titun-windows-gui/NetworkConfigManager.cs
+++ b/titun-windows-gui/titun-windows-gui/NetworkConfigManager.cs
@@ -340,7 +340,7 @@ namespace titun_windows_gui
         }
 
         [MethodImpl(MethodImplOptions.Synchronized)]
-        public void AutomaticConfig(Config config, BufferBlock<string> output, out IEnumerable<string> routesAdded)
+        public void AutomaticConfig(string interfaceName, Config config, BufferBlock<string> output, out IEnumerable<string> routesAdded)
         {
             var routes = new List<string>();
             void Try(string description, Action op)
@@ -359,7 +359,7 @@ namespace titun_windows_gui
             uint index;
             try
             {
-                index = FindInterfaceIndexByAlias(config.Interface.Name) ?? throw new Exception($"Failed to find interface {config.Interface.Name}");
+                index = FindInterfaceIndexByAlias(interfaceName) ?? throw new Exception($"Failed to find interface {interfaceName}");
             }
             catch (Exception e)
             {


### PR DESCRIPTION
And remove the `Interface.Name` configuration option.

This is more in line with `wg-quick` and wireguard-windows.
