### PR TITLE
Build the debian package with musl

### DIFF
--- a/debian/build-deb.sh
+++ b/debian/build-deb.sh
@@ -2,8 +2,8 @@
 
 set -e
 
-cargo build --release
+cross build --release --target=x86_64-unknown-linux-musl
 mkdir -p package/usr/bin/
-cp ../target/release/titun package/usr/bin/titun
+cp ../target/x86_64-unknown-linux-musl/release/titun package/usr/bin/titun
 trap "rm package/usr/bin/titun" 0
 fakeroot dpkg-deb --build package titun.deb


### PR DESCRIPTION
So we don't need to worry about glibc versions. It's also a bit faster.

bors r+