### PR TITLE
Fix ns test

### DIFF
--- a/ns-test/integration-test.sh
+++ b/ns-test/integration-test.sh
@@ -3,8 +3,8 @@
 set -ex
 
 clean_up() {
-    set +e
     r=$?
+    set +e
     ./clean-up.sh
     git checkout -- tun1.conf tun2.conf
     exit $r

--- a/ns-test/interop-test.sh
+++ b/ns-test/interop-test.sh
@@ -3,8 +3,8 @@
 set -ex
 
 clean_up() {
-    set +e
     r=$?
+    set +e
     ./clean-up.sh
     exit $r
 }

--- a/src/async_utils.rs
+++ b/src/async_utils.rs
@@ -80,11 +80,12 @@ impl AsyncScope {
         T: Future<Output = ()> + Send + 'static,
     {
         let cancelled = self.cancelled();
+
         tokio::spawn(async move {
-            tokio::select! {
-                _ = cancelled => {}
-                _ = future => {}
-            }
+            futures::select_biased! {
+                _ = future.fuse() => {}
+                _ = cancelled.fuse() => {}
+            };
         });
     }
 }

--- a/src/ipc/server.rs
+++ b/src/ipc/server.rs
@@ -58,6 +58,7 @@ pub async fn ipc_server(
     dev_name: &OsStr,
     ready: Sender<()>,
 ) -> anyhow::Result<()> {
+    use futures::prelude::*;
     use nix::sys::stat::{umask, Mode};
     use std::fs::{create_dir_all, remove_file};
     use tokio::net::UnixListener;
@@ -71,24 +72,24 @@ pub async fn ipc_server(
     let mut listener = UnixListener::bind(path.as_path()).context("failed to bind IPC socket")?;
 
     let deleted = super::wait_delete::wait_delete(&path, ready);
-    tokio::pin!(deleted);
-
-    loop {
-        tokio::select! {
-            deleted_result = &mut deleted => {
-                deleted_result?;
-                info!("IPC socket deleted. Shutting down.");
-                return Ok(());
-            }
-            accept_result = listener.accept() => {
-                let (stream, _) = accept_result?;
-                let wg = wg.clone();
-                tokio::spawn(async move {
-                    serve(&wg, stream).await.unwrap_or_else(|e| {
-                        warn!("Error serving IPC connection: {:#}", e);
-                    });
+    let accept_and_handle = async move {
+        loop {
+            let (stream, _) = listener.accept().await?;
+            let wg = wg.clone();
+            tokio::spawn(async move {
+                serve(&wg, stream).await.unwrap_or_else(|e| {
+                    warn!("Error serving IPC connection: {:#}", e);
                 });
-            }
+            });
+        }
+    };
+
+    futures::select_biased! {
+        result = accept_and_handle.fuse() => result,
+        deleted_result = deleted.fuse() => {
+            deleted_result?;
+            info!("IPC socket deleted. Shutting down.");
+            Ok(())
         }
     }
 }


### PR DESCRIPTION
There was a bug introduced in #149, but our integration test failed to detect it.

This bug seems to be that setting listening port does not correctly wake up the UDP receiving task. This is fixed by switching to `futures::select_biased` macro instead of `tokio::select`.
